### PR TITLE
Improve default performance significantly with optimisation flags

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -59,7 +59,14 @@ executables:
     ghc-options:
     - -threaded
     - -rtsopts
-    - -with-rtsopts=-N
+    - -with-rtsopts=-N4
+    - -with-rtsopts=-qa
+    - -with-rtsopts=-C0
+    - -funfolding-use-threshold=16
+    - -fexcess-precision
+    - -optc-O3
+    - -optc-ffast-math
+    - -O2
     default-extensions:
     - EmptyCase
     - FlexibleContexts


### PR DESCRIPTION
Add a large number of flags to the GHC options for the executable version of the aoc template.

These are as follows:

* `-with-rtsopts=-N4` : Run the program across a reasonable number of cores by default. I found 4 to be a sensible balance and should not exceed the number of available cores on any modern machine. Moreover `-N` (using the maximum possible number of cores) has a habit of introducing switching delays (cf. https://gitlab.haskell.org/ghc/ghc/-/issues/8224).
* `-with-rtsopts=-qa`: Pin threads to CPU cores, if the operating system permits. Reduces OS-induced switching costs.
* `-with-rtsopts=-C0`: Allow switching as often as the machine decides it needs it, rather than having a lower bound of 50ms.
* `-funfolding-use-threshold=16`: Reduce unfolding at call site. Can improve performance.
* `-fexcess-precision`: Permit extra floating-point precision at intermediate steps, if it will increase performance. May alter the value of floats and doubles in cases where those computations are imprecise.
* `-optc-O3`: Enable `-O3` at the C compilation step. Enables a suite of optimisations in the C compiler.
* `-optc-ffast-math`: Enable `-ffast-math` at the C compilation step. Again messes with (pseudo-invalid uses of) floats and doubles in the interests of speed.
* `-O2` - Enables a suite of GHC optimisations.